### PR TITLE
fix(Sassify.module): correct glob to match files

### DIFF
--- a/Sassify.module
+++ b/Sassify.module
@@ -143,7 +143,7 @@ class Sassify extends WireData implements Module {
      */
     public static function sassifyAll() {
         // get timestamp of most recently modified SCSS file
-        $files = glob( self::$sassPath );
+        $files = glob( self::$sassPath . '*' );
         $times = array_map('filemtime', $files);
         arsort($times);
         $scss_time = current($times);


### PR DESCRIPTION
The current check (`glob( self::$sassPath )`) just runs `filemtime` on the folder which doesn't result in correct modified times. 